### PR TITLE
Fix `$DRACULA_ARROW_ICON` getting parsed as a command-line flag to `print`

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -79,9 +79,9 @@ fi
 # Status segment {{{
 dracula_arrow() {
 	if [[ "$1" = "start" ]] && (( ! DRACULA_DISPLAY_NEW_LINE )); then
-		print -P "$DRACULA_ARROW_ICON"
+		print -P -- "$DRACULA_ARROW_ICON"
 	elif [[ "$1" = "end" ]] && (( DRACULA_DISPLAY_NEW_LINE )); then
-		print -P "\n$DRACULA_ARROW_ICON"
+		print -P -- "\n$DRACULA_ARROW_ICON"
 	fi
 }
 


### PR DESCRIPTION
When `$DRACULA_ARROW_ICON` begins with an unescaped `-` character, it will be read as a command line flag by the `print` command. This causes the error `dracula_arrow:print:2: bad option: -> ` (for example) to get outputted on each new prompt line. This PR passes the `--` flag to `print` before passing `$DRACULA_ARROW_ICON` to ensure that `print` does not attempt to parse the arrow icon as a command-line flag.